### PR TITLE
Implement standard IO for the compile command

### DIFF
--- a/src/frontend/protocol_spec/ast/parser.rs
+++ b/src/frontend/protocol_spec/ast/parser.rs
@@ -27,7 +27,8 @@ fn format_error(input: &str, error: pds::ParseError) -> String {
     let pointer_padding = (0..error.column+1).map(|_| " ").join("");
     let pointer = "^";
 
-    println!("{:?}", error);
+    use std::io::{Write, stderr};
+    writeln!(&mut stderr(), "{:?}", error).unwrap();
     format!("{}\n{}{}", lines_f, pointer_padding, pointer)
 }
 

--- a/src/frontend/protocol_spec/to_ir/compilation_unit.rs
+++ b/src/frontend/protocol_spec/to_ir/compilation_unit.rs
@@ -40,6 +40,7 @@ fn block_to_compilation_unit_ns(block: &ast::Block,
     for stmt in &block.statements {
         let head_item = stmt.items[0].item()
             .ok_or("statement in root must start with item")?;
+
         let head_item_name = head_item.name
             .simple_str()
             .ok_or("statement in root must start with non-namespaced item")?;

--- a/src/protodefc.rs
+++ b/src/protodefc.rs
@@ -80,24 +80,21 @@ fn main() {
 
 fn run(matches: &clap::ArgMatches) -> Result<()> {
     if let Some(ref matches) = matches.subcommand_matches("compile") {
-        let target = value_t!(matches, "TARGET", CompileTarget)
-            .unwrap_or_else(|e| e.exit());
+        let backend: Backend = value_t!(matches, "TARGET", CompileTarget)
+            .unwrap_or_else(|e| e.exit()).into();
 
         let input_file = matches.value_of("INPUT").unwrap();
         let output_file = matches.value_of("OUTPUT").unwrap();
 
-        let mut input_file = File::open(input_file).unwrap();
+        let mut input_file = open_input(input_file);
+        let mut output_file = open_output(output_file);
+
         let mut input_str = String::new();
         input_file.read_to_string(&mut input_str).unwrap();
 
         let cu = protodefc::spec_to_final_compilation_unit(&input_str)?;
 
-        let backend: Backend = target.into();
-
-        let out = backend(&cu)?;
-
-        let mut output_file = File::create(output_file).unwrap();
-        output_file.write(out.as_bytes()).unwrap();
+        output_file.write(backend(&cu)?.as_bytes()).unwrap();
     }
 
     if let Some(ref matches) = matches.subcommand_matches("old_protodef_to_pds") {
@@ -117,6 +114,37 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn open_input(name: &str) -> File {
+    #[cfg(any(unix))]
+    {
+        use std::os::unix::io::FromRawFd;
+        if (name == "-") {
+            // NOTE: This is unsafe because File expects that it
+            // is the sole user of this descriptor. Any access to
+            // standard input in other locations could cause issues
+            return unsafe { File::from_raw_fd(0) }
+        }
+    }
+
+    File::open(name).unwrap()
+}
+
+fn open_output(name: &str) -> File {
+    #[cfg(any(unix))]
+    {
+        use std::os::unix::io::FromRawFd;
+        if (name == "-") {
+            // NOTE: This is unsafe because File expects that it
+            // is the sole user of this descriptor. Any access to
+            // standard output in other locations (like println!)
+            // cause issues
+            return unsafe { File::from_raw_fd(1) }
+        }
+    }
+
+    File::create(name).unwrap()
 }
 
 impl Into<Backend> for CompileTarget {


### PR DESCRIPTION
Enables command line use like so:

`$ protodefc compile javascript - - < test.pds`

However there are some memory safety concerns here.

From the [`FromRawFd`](https://doc.rust-lang.org/beta/std/os/unix/io/trait.FromRawFd.html) docs


> This function is also unsafe as the primitives currently returned have the contract that they are the 
> sole owner of the file descriptor they are wrapping. Usage of this function could accidentally allow 
> violating this contract which can cause memory unsafety in code that relies on it being true.

If standard input or output (like println!) are used anywhere else in the code, memory unsafety could arise.